### PR TITLE
SimplexNoise.uplugin linux support

### DIFF
--- a/SimplexNoise.uplugin
+++ b/SimplexNoise.uplugin
@@ -16,9 +16,8 @@
 		{
 			"Name" : "SimplexNoise",
 			"Type" : "Runtime",
-			"LoadingPhase" : "PreDefault",
-			"WhitelistPlatforms" : [ "Win64", "Win32", "Mac" ]
-		},
+			"LoadingPhase" : "PreDefault"
+		}
 
 		
 	]


### PR DESCRIPTION
Plugin compiles and builds on Linux as-is (tested on Ubuntu 16.04.5 LTS 64-bit, UE4.21.1); exclusive WhitelistPlatforms does not allow plugin to be detected and imported by UE4Editor